### PR TITLE
Task CS-2206: PyDomainExtractor | Add arm64 build on deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Cross-compilers (macOS)
         if: matrix.os == 'macos-latest'
         run: |
-          rustup target add x86_64-unknown-linux-gnu
+          rustup target add x86_64-apple-darwin
           rustup target add aarch64-apple-darwin
       - name: Publish Package
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,10 +32,32 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - name: Install Cross-compilers (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install FiloSottile/musl-cross/musl-cross
+          brew install mingw-w64
       - name: Publish Package
         uses: PyO3/maturin-action@v1
         with:
           command: publish
           args: --username=__token__ ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.7' && '' || '--no-sdist' }} --interpreter=python${{ !startsWith(matrix.os, 'windows') && matrix.python-version || '' }}
+        env:
+          MATURIN_PASSWORD: ${{ secrets.pypi_password }}
+        if: matrix.os != 'macos-latest'
+      - name: Publish macOS (x86_64) Package
+        if: matrix.os == 'macos-latest'
+        uses: PyO3/maturin-action@v1
+        with:
+          command: publish
+          args: --username=__token__ --interpreter=python${{ matrix.python-version }} --target=x86_64-apple-darwin
+        env:
+          MATURIN_PASSWORD: ${{ secrets.pypi_password }}
+      - name: Publish macOS (arm64) Package
+        if: matrix.os == 'macos-latest'
+        uses: PyO3/maturin-action@v1
+        with:
+          command: publish
+          args: --username=__token__ --interpreter=python${{ matrix.python-version }} --target=aarch64-apple-darwin
         env:
           MATURIN_PASSWORD: ${{ secrets.pypi_password }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Install Cross-compilers (macOS)
         if: matrix.os == 'macos-latest'
         run: |
-          brew install FiloSottile/musl-cross/musl-cross
-          brew install mingw-w64
+          rustup target add x86_64-unknown-linux-gnu
+          rustup target add aarch64-apple-darwin
       - name: Publish Package
         uses: PyO3/maturin-action@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.vscode/
 
 # C extensions
 *.so
@@ -100,7 +101,7 @@ ipython_config.py
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
+poetry.lock
 
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,21 +17,6 @@ keywords = [
     "pyo3",
 ]
 
-[package.metadata.maturin]
-requires-python = ">=3.7"
-classifier = [
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: MacOS",
-    "Operating System :: Microsoft",
-    "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Rust",
-]
-
 [lib]
 name = "pydomainextractor"
 crate-type = ["cdylib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pydomainextractor"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Gal Ben David <gal@intsights.com>"]
 edition = "2021"
 description = "A blazingly fast domain extraction library written in Rust"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,10 @@
 name = "pydomainextractor"
 version = "0.13.0"
 description = "A blazingly fast domain extraction library written in Rust"
-authors = ["Gal Ben David <gal@intsights.com>"]
+
+[project.authors]
+name = "Gal Ben David"
+email = "gal@intsights.com"
 
 [project.urls]
 repository = "https://github.com/intsights/pydomainextractor"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,19 @@ authors = [
   {name = "Gal Ben David"}
 ]
 requires-python = ">=3.7"
+license = "MIT"
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: MacOS",
+  "Operating System :: Microsoft",
+  "Operating System :: POSIX :: Linux",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Rust",
+]
 
 [project.urls]
 repository = "https://github.com/intsights/pydomainextractor"
@@ -73,20 +86,4 @@ addopts = [
 ]
 testpaths = [
     "tests",
-]
-
-[project.classifiers]
-license = "License :: OSI Approved :: MIT License"
-operating-system = [
-  "MacOS",
-  "Microsoft",
-  "POSIX :: Linux",
-]
-programming-language = [
-  "Python :: 3.7",
-  "Python :: 3.8",
-  "Python :: 3.9",
-  "Python :: 3.10",
-  "Python :: 3.11",
-  "Rust",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,11 @@
 name = "pydomainextractor"
 version = "0.13.0"
 description = "A blazingly fast domain extraction library written in Rust"
-
-[project.authors]
-name = "Gal Ben David"
-email = "gal@intsights.com"
+authors = [
+  {email = "gal@intsights.com"},
+  {name = "Gal Ben David"}
+]
+requires-python = ">=3.7"
 
 [project.urls]
 repository = "https://github.com/intsights/pydomainextractor"
@@ -73,15 +74,6 @@ addopts = [
 testpaths = [
     "tests",
 ]
-
-[project.metadata]
-requires-python = ">=3.7"
-
-[project.release]
-requires-python = ">=3.7"
-
-[project.sdist]
-requires-python = ">=3.7"
 
 [project.classifiers]
 license = "License :: OSI Approved :: MIT License"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,13 @@
+[project]
+name = "pydomainextractor"
+version = "0.13.0"
+description = "A blazingly fast domain extraction library written in Rust"
+authors = ["Gal Ben David <gal@intsights.com>"]
+
+[project.urls]
+repository = "https://github.com/intsights/pydomainextractor"
+homepage = "https://github.com/intsights/pydomainextractor"
+
 [build-system]
 requires = ["maturin>=0.14,<0.15"]
 build-backend = "maturin"
@@ -59,4 +69,29 @@ addopts = [
 ]
 testpaths = [
     "tests",
+]
+
+[project.metadata]
+requires-python = ">=3.7"
+
+[project.release]
+requires-python = ">=3.7"
+
+[project.sdist]
+requires-python = ">=3.7"
+
+[project.classifiers]
+license = "License :: OSI Approved :: MIT License"
+operating-system = [
+  "MacOS",
+  "Microsoft",
+  "POSIX :: Linux",
+]
+programming-language = [
+  "Python :: 3.7",
+  "Python :: 3.8",
+  "Python :: 3.9",
+  "Python :: 3.10",
+  "Python :: 3.11",
+  "Rust",
 ]


### PR DESCRIPTION
Add arm64 build for the package by adding cross-compiler to the CI "deploy" workflow. This will allow to build package both for x86 and arm64 architectures of macbook processors. 
https://intsights.atlassian.net/browse/CS-2537