### PR TITLE
Fix segmentation fault in extract_from_url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pydomainextractor"
-version = "0.13.4"
+version = "0.13.5"
 authors = ["Gal Ben David <gal@intsights.com>"]
 edition = "2021"
 description = "A blazingly fast domain extraction library written in Rust"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydomainextractor"
-version = "0.13.4"
+version = "0.13.5"
 description = "A blazingly fast domain extraction library written in Rust"
 authors = [
   {email = "gal@intsights.com"},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,6 +254,9 @@ impl DomainExtractor {
             );
         }
 
+        if url_str.len() > 255 {
+            return Err(PyValueError::new_err("Invalid domain detected"));
+        }
         let mut domain_string = unsafe {
             DomainString::from_str_unchecked(url_str)
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,7 @@ impl DomainExtractor {
         }
 
         if url_str.len() > 255 {
-            return Err(PyValueError::new_err("Invalid domain detected"));
+            return Err(PyValueError::new_err("url is invalid: too long"));
         }
         let mut domain_string = unsafe {
             DomainString::from_str_unchecked(url_str)

--- a/tests/test_pydomainextractor.py
+++ b/tests/test_pydomainextractor.py
@@ -301,6 +301,14 @@ class DomainExtractorExtractionTestCase(
         ):
             self.domain_extractor.extract('com.')
 
+    def test_domain_too_long(
+        self,
+    ):
+        with self.assertRaises(
+            expected_exception=ValueError,
+        ):
+            self.domain_extractor.extract(f'{"very-long" * 255}.com')
+
     def test_extract_from_url(
         self,
     ):

--- a/tests/test_pydomainextractor.py
+++ b/tests/test_pydomainextractor.py
@@ -349,6 +349,11 @@ class DomainExtractorExtractionTestCase(
         ):
             self.domain_extractor.extract_from_url('co.uk')
 
+        with self.assertRaises(
+            ValueError,
+        ):
+            self.domain_extractor.extract_from_url(f'http://{"domain" * 255}co.uk:3030/some/path')
+
         self.assertEqual(
             first=self.domain_extractor.extract_from_url('http://www.google.com'),
             second={


### PR DESCRIPTION
In the method `extract_from_url`, after we parse the URL and get the domain itself, we load it into a `DomainString` object, which is an `arraystring` object with a fixed size of 255. We use the unsafe `from_str_unchecked` method to do this, which means we need to make sure ourself the string is not too long.
While in the method `extract` there is a check that the domain is not longer than 255, this check is missing in `extract_from_url`. And thus, calling this method with URLs that have a domain part which is longer than 255 characters might cause a segmentation fault.
I added this check, which will return a Python `ValueError` in case it fails.

I also added a unit test that would have caught this error, and a similar one for `extract`.

I used the error message `"Invalid domain detected"`, which is the one used in the parallel case in the `extract` method, in order to keep consistency. However we can convey more information in both `extract` and `extract_from_url`, so I might suggest changing them to something like `Domain is too long` in a future PR.