### PR TITLE
Fix: fix c_char type bug and add source dist

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,3 +73,12 @@ jobs:
           args: --username=__token__ --interpreter=python${{ matrix.python-version }} --target=aarch64-unknown-linux-gnu --no-sdist
         env:
           MATURIN_PASSWORD: ${{ secrets.pypi_password }}
+  dist-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Distribute Source
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+        env:
+          MATURIN_PASSWORD: ${{ secrets.pypi_password }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pydomainextractor"
-version = "0.13.9"
+version = "0.13.10"
 authors = ["Viktor Vilskyi <viktor_vilskyi@rapid7.com>"]
 edition = "2021"
 repository = "https://github.com/intsights/pydomainextractor"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydomainextractor"
-version = "0.13.9"
+version = "0.13.10"
 authors = [
   {email = "viktor_vilskyi@rapid7.com"},
   {name = "Viktor Vilskyi"}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyString;
+use std::os::raw::c_char;
 
 type DomainString = arraystring::ArrayString<typenum::U255>;
 
@@ -144,7 +145,7 @@ impl DomainExtractor {
             ] {
                 if !fraction.is_empty() {
                     let substr = pyo3::ffi::PyUnicode_FromStringAndSize(
-                        fraction.as_ptr() as *const i8,
+                        fraction.as_ptr() as *const c_char,
                         fraction.len() as isize,
                     );
 
@@ -273,7 +274,7 @@ impl DomainExtractor {
             ] {
                 if !fraction.is_empty() {
                     let substr = pyo3::ffi::PyUnicode_FromStringAndSize(
-                        fraction.as_ptr() as *const i8,
+                        fraction.as_ptr() as *const c_char,
                         fraction.len() as isize,
                     );
 


### PR DESCRIPTION
There is a bug, where we call the function `pyo3::ffi::PyUnicode_FromStringAndSize` with the wrong parameter - `i8` instead of `c_char`. This is probably because the documentation also wrongfully used `i8`. `c_char` can be `i8` or `u8`, depending on the system, so that's the reason why it compiles on some systems and doesn't work on others.

I also added a source distribution, to allow installing with `pip` on systems where the precompiled release won't work, like the `python3.11-alpine` docker image.
