### PR TITLE
chore: add Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "schedule": ["* 3,15 * * *"],
+  "extends": [
+    "config:recommended",
+    "group:recommended"
+  ],
+  "lockFileMaintenance": { "enabled": true },
+  "pruneStaleBranches": false,
+  "ignoreDeps": ["python"],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchCategories": [
+        "python"
+      ],
+      "groupName": "all non-major python dependencies",
+      "groupSlug": "all-minor-patch-python"
+    }
+  ]
+}


### PR DESCRIPTION
Automated change across non-archived Intsights repositories.
- Adds `.github/renovate.json` so Renovate manages Python dependency updates.